### PR TITLE
glide.yaml: set california branch for edgex-go package

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -7,5 +7,6 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: v3.2.0
 - package: github.com/edgexfoundry/edgex-go
+  version: california
   subpackages:
   - support/logging-client


### PR DESCRIPTION
The current master edgex-go doesn't have the package installed in the same place anymore, and we should be pinned to a specific revision of the edgex-go package anyways.

fixes #13 