### PR TITLE
Skip the steps if the services and routes are initialized already.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCKERS=docker_edgexproxy
 MICROSERVICES=edgexproxy
 .PHONY: $(MICROSERVICES)
 VERSION=$(shell cat ./VERSION)
-GIT_SHA=$(shell git rev-parse --short HEAD)
+GIT_SHA=$(shell git rev-parse HEAD)
 
 prepare:
 	glide install


### PR DESCRIPTION
To test the whole security component, please follow the steps below: 

1. go to security-secret-store folder
  $ make build
  $ make docker

2. go to security-api-gateway folder
 $ make build
 $ make docker
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d volume
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d config-seed
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d consul
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d vault
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d vault-worker
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d kong-db
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d kong-migrations
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d kong
 $ docker-compose -f docker-compose-proxy-0.6.0.yml up -d edgex-proxy

If we'd like to see the progress, just drop the "-d" option so everything will be displayed on the console. 
