### PR TITLE
Makefile: remove GOARCH=amd64 setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 .PHONY: build clean docker run
-GO=CGO_ENABLED=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go
+GO=CGO_ENABLED=0 GO111MODULE=on GOOS=linux go
 DOCKERS=docker_edgexproxy
 .PHONY: $(DOCKERS)
 MICROSERVICES=edgexproxy


### PR DESCRIPTION
This allows the native GOARCH setting (or the user's) to be used
instead.

Fixes #59