### PR TITLE
core/certs.go, kongParameters.go: use JSON instead of form

### DIFF
--- a/core/certs.go
+++ b/core/certs.go
@@ -37,7 +37,7 @@ func loadKongCerts(config *tomlConfig, url string, secretBaseURL string, c *http
 	}
 
 	lc.Info("Trying to upload cert to proxy server.")
-	req, err := sling.New().Base(url).Post(CertificatesPath).BodyForm(body).Request()
+	req, err := sling.New().Base(url).Post(CertificatesPath).BodyJSON(body).Request()
 	resp, err := c.Do(req)
 	if err != nil {
 		lc.Error("Failed to upload cert to proxy server with error %s", err.Error())

--- a/core/kongParameters.go
+++ b/core/kongParameters.go
@@ -99,9 +99,9 @@ type CertCollect struct {
 }
 
 type CertInfo struct {
-	Cert string   `url:"cert,omitempty"`
-	Key  string   `url:"key,omitempty"`
-	Snis []string `url:"snis,omitempty"`
+	Cert string   `json:"cert,omitempty"`
+	Key  string   `json:"key,omitempty"`
+	Snis []string `json:"snis,omitempty"`
 }
 
 type JWTCred struct {


### PR DESCRIPTION
Use JSON to post the certificates rather than the Form, as JSON is now
more reliable than using the application/x-www-form-urlencoded method.

There are some race conditions which sometimes lead to Kong not picking
up the SNIs setting for the certificate, which in turn leads to Kong
picking the wrong certs to serve with for endpoints.

This is the second part of the fix for https://github.com/edgexfoundry/edgex-go/issues/1458